### PR TITLE
fix: Remove spliced alignments from DP calculation

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,15 +12,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get --assume-yes install build-essential libcurl4-openssl-dev libz-dev liblzma-dev
         python -m pip install --upgrade pip
-        pip cache purge
         pip install setuptools wheel
         # this is needed by pybedtools
         sudo apt-get --assume-yes install bedtools
@@ -28,7 +28,6 @@ jobs:
         pip install -r requirements.txt
     - name: Install vafator
       run: |
-        pip cache purge
         python setup.py bdist_wheel
         pip install dist/vafator-*.whl
     - name: Run integration tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,6 +20,7 @@ jobs:
         sudo apt-get update
         sudo apt-get --assume-yes install build-essential libcurl4-openssl-dev libz-dev liblzma-dev
         python -m pip install --upgrade pip
+        pip cache purge
         pip install setuptools wheel
         # this is needed by pybedtools
         sudo apt-get --assume-yes install bedtools

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -25,7 +25,7 @@ jobs:
         # this is needed by pybedtools
         sudo apt-get --assume-yes install bedtools
         # install python requirements
-        pip install -r requirements.txt
+        #pip install -r requirements.txt
     - name: Install vafator
       run: |
         python setup.py bdist_wheel

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,32 +4,26 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
-      with:
+        with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get --assume-yes install build-essential libcurl4-openssl-dev libz-dev liblzma-dev
-        python -m pip install --upgrade pip
-        pip install setuptools wheel
-        # this is needed by pybedtools
-        sudo apt-get --assume-yes install bedtools
-        # install python requirements
-        #pip install -r requirements.txt
-    - name: Install vafator
-      run: |
-        python setup.py bdist_wheel
-        pip install dist/vafator-*.whl
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install .
+
     - name: Run integration tests
       run: |
         make clean integration_tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,7 @@ jobs:
         pip install -r requirements.txt
     - name: Install vafator
       run: |
+        pip cache purge
         python setup.py bdist_wheel
         pip install dist/vafator-*.whl
     - name: Run integration tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    
+    - uses: actions/setup-python@v5
+      with:
+          python-version: 3.10
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip cache purge
         pip install setuptools wheel twine
+    
     - name: Build and publish
       env:
         TWINE_USERNAME: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip cache purge
         pip install setuptools wheel twine
     
     - name: Build and publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip cache purge
         pip install setuptools wheel twine
     - name: Build and publish
       env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,6 +24,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install .
+          pip install coverage codecov
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,8 +1,6 @@
 name: Unit tests
 
-on:
-  push:
-  pull_request:
+on: [push]
 
 jobs:
   test:
@@ -24,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install .
-          pip install coverage codecov
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Build, install and run unit tests
       run: |
         pip install -r requirements.txt
-        pip install --force-reinstall "numpy==1.24.4"
-        pip install --no-cache-dir --force-reinstall --no-binary :all: cyvcf2
+        pip install --force-reinstall numpy
+        pip install --no-cache-dir --force-reinstall --no-binary :all: cyvcf2==0.30.14
         coverage run -m unittest discover vafator.tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,9 +23,9 @@ jobs:
         pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
     - name: Build, install and run unit tests
       run: |
-        pip install -r requirements.txt
         pip install --no-binary=:all: numpy
         pip install --no-binary=:all: cyvcf2
+        pip install -r requirements.txt
         coverage run -m unittest discover vafator.tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -14,15 +14,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install Python dependencies
+    - name: Install dependencies
       run: |
+        python -m pip install --upgrade pip
         pip install setuptools wheel coverage
-        pip install -r requirements.txt
-
-    - name: Run unit tests with coverage
+        pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
+    - name: Build, install and run unit tests
       run: |
+        pip install -r requirements.txt
+        pip install --force-reinstall "numpy==1.24.4"
+        pip install --no-cache-dir --force-reinstall --no-binary :all: cyvcf2
         coverage run -m unittest discover vafator.tests
-
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -4,28 +4,25 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.8', '3.9', '3.10' ]
 
+    container:
+      image: python:${{ matrix.python-version }}
+
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: pip
-    - name: Install dependencies
+
+    - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install setuptools wheel coverage
-        pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
-    - name: Build, install and run unit tests
-      run: |
-        pip install --no-binary=:all: numpy
-        pip install --no-binary=:all: cyvcf2
         pip install -r requirements.txt
+
+    - name: Run unit tests with coverage
+      run: |
         coverage run -m unittest discover vafator.tests
+
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,6 +23,7 @@ jobs:
         pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
     - name: Build, install and run unit tests
       run: |
+        pip cache purge
         pip install -r requirements.txt
         coverage run -m unittest discover vafator.tests
     - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,18 +12,17 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip cache purge
         pip install setuptools wheel coverage
         pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
     - name: Build, install and run unit tests
       run: |
-        pip cache purge
         pip install -r requirements.txt
         coverage run -m unittest discover vafator.tests
     - name: Upload Coverage to Codecov

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -18,6 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip cache purge
         pip install setuptools wheel coverage
         pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
     - name: Build, install and run unit tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,6 +24,8 @@ jobs:
     - name: Build, install and run unit tests
       run: |
         pip install -r requirements.txt
+        pip install --no-binary=:all: numpy
+        pip install --no-binary=:all: cyvcf2
         coverage run -m unittest discover vafator.tests
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,29 +1,35 @@
 name: Unit tests
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
-
-    container:
-      image: python:${{ matrix.python-version }}
+        python-version: [3.8, 3.9, 3.10]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel coverage
-        pip install virtualenv tox==3.26.0 tox-wheel==1.0.0 tox-gh-actions
-    - name: Build, install and run unit tests
-      run: |
-        pip install -r requirements.txt
-        pip install --force-reinstall numpy
-        pip install --no-cache-dir --force-reinstall --no-binary :all: cyvcf2==0.30.14
-        coverage run -m unittest discover vafator.tests
-    - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install coverage codecov
+
+      - name: Run tests with coverage
+        run: |
+          coverage run -m unittest discover
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pysam~=0.19.1
 cyvcf2~=0.30.14
 logzero~=1.7.0
 pybedtools~=0.9.0
+numpy==1.26.4
 scipy>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pysam~=0.19.1
 cyvcf2~=0.30.14
 logzero~=1.7.0
 pybedtools~=0.9.0
-numpy==1.26.4
+numpy>=1.20,<2.0
 scipy>=1.0.0,<2.0.0

--- a/vafator/__init__.py
+++ b/vafator/__init__.py
@@ -1,4 +1,4 @@
-VERSION='2.2.0'
+VERSION='2.2.1'
 
 
 AMBIGUOUS_BASES = ['N', 'M', 'R', 'W', 'S', 'Y', 'K', 'V', 'H', 'D', 'B']

--- a/vafator/pileups.py
+++ b/vafator/pileups.py
@@ -183,7 +183,7 @@ def get_snv_metrics(pileups: IteratorColumnRegion, include_ambiguous_bases=False
         if include_ambiguous_bases:
             dp = len(bases)
         else:
-            dp = len([b for b in bases if b not in AMBIGUOUS_BASES])
+            dp = len([b for b in bases if b not in AMBIGUOUS_BASES and b != ""])
         ac = Counter(bases)
     except StopIteration:
         # no reads

--- a/vafator/pileups.py
+++ b/vafator/pileups.py
@@ -181,7 +181,7 @@ def get_snv_metrics(pileups: IteratorColumnRegion, include_ambiguous_bases=False
         all_positions = aggregate_list_per_base(bases, pileup.get_query_positions())
 
         if include_ambiguous_bases:
-            dp = len(bases)
+            dp = len([b for b in bases if b!= ""])
         else:
             # remove ambiguous bases and reads where the position is spliced out
             dp = len([b for b in bases if b not in AMBIGUOUS_BASES and b != ""])

--- a/vafator/pileups.py
+++ b/vafator/pileups.py
@@ -183,6 +183,7 @@ def get_snv_metrics(pileups: IteratorColumnRegion, include_ambiguous_bases=False
         if include_ambiguous_bases:
             dp = len(bases)
         else:
+            # remove ambiguous bases and reads where the position is spliced out
             dp = len([b for b in bases if b not in AMBIGUOUS_BASES and b != ""])
         ac = Counter(bases)
     except StopIteration:


### PR DESCRIPTION
For positions overlapped by spliced alignments, only reads that actually map to the position of interest are counted for the depth calculation.

Additionally fixed CI pipeline (finally)